### PR TITLE
Fix failing spec

### DIFF
--- a/spec/tenkit/spec_helper.rb
+++ b/spec/tenkit/spec_helper.rb
@@ -4,6 +4,15 @@ require 'webmock/rspec'
 require 'dotenv'
 Dotenv.load
 
+ENV['AUTH_KEY'] = <<~PKEY
+  -----BEGIN PRIVATE KEY-----
+  MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgvDhFoOhIgO3j/1KT
+  D/tGcxdMK9ILbIPv63GO4IlkrMagCgYIKoZIzj0DAQehRANCAAQGjZk+nabnYj16
+  7wADUWYq4xFQ4tAKfNmjPTHQm0YGV/eUhfEsVgtV0N8jR3baRuHMFlEbAyyiN46G
+  efTzbRg+
+  -----END PRIVATE KEY-----
+  PKEY
+
 Tenkit.configure do |c|
   c.team_id = ENV.fetch('TID')
   c.service_id = ENV.fetch('SID')

--- a/spec/tenkit/tenkit_spec.rb
+++ b/spec/tenkit/tenkit_spec.rb
@@ -4,6 +4,18 @@ require_relative './mock/weather'
 RSpec.describe Tenkit do
   let(:api_url) { "https://weatherkit.apple.com/api/v1"  }
   let(:data_sets) { Tenkit::Client::DATA_SETS }
+  let(:pkey) do
+    <<~PKEY
+    -----BEGIN PRIVATE KEY-----
+    MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgvDhFoOhIgO3j/1KT
+    D/tGcxdMK9ILbIPv63GO4IlkrMagCgYIKoZIzj0DAQehRANCAAQGjZk+nabnYj16
+    7wADUWYq4xFQ4tAKfNmjPTHQm0YGV/eUhfEsVgtV0N8jR3baRuHMFlEbAyyiN46G
+    efTzbRg+
+    -----END PRIVATE KEY-----
+    PKEY
+  end
+
+  before {Tenkit.configure {|c| c.key = pkey} }
 
   subject { Tenkit::Client.new }
 

--- a/spec/tenkit/tenkit_spec.rb
+++ b/spec/tenkit/tenkit_spec.rb
@@ -4,18 +4,6 @@ require_relative './mock/weather'
 RSpec.describe Tenkit do
   let(:api_url) { "https://weatherkit.apple.com/api/v1"  }
   let(:data_sets) { Tenkit::Client::DATA_SETS }
-  let(:pkey) do
-    <<~PKEY
-    -----BEGIN PRIVATE KEY-----
-    MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgvDhFoOhIgO3j/1KT
-    D/tGcxdMK9ILbIPv63GO4IlkrMagCgYIKoZIzj0DAQehRANCAAQGjZk+nabnYj16
-    7wADUWYq4xFQ4tAKfNmjPTHQm0YGV/eUhfEsVgtV0N8jR3baRuHMFlEbAyyiN46G
-    efTzbRg+
-    -----END PRIVATE KEY-----
-    PKEY
-  end
-
-  before {Tenkit.configure {|c| c.key = pkey} }
 
   subject { Tenkit::Client.new }
 


### PR DESCRIPTION
Turns out we need to use a real PKEY, so I set a real but revoked PKEY.

The `AUTH_KEY` environment variable needs to be set in the Github repo.

Maybe the spec helper should populate all config attributes — when missing — so the specs can run locally even when folks have not populated their local environment.