### PR TITLE
Client: Allow users to pass a token

### DIFF
--- a/lib/tenkit.rb
+++ b/lib/tenkit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'tenkit/container'
+require_relative 'tenkit/authentication'
 require_relative 'tenkit/client'
 require_relative 'tenkit/config'
 require_relative 'tenkit/version'

--- a/lib/tenkit/authentication.rb
+++ b/lib/tenkit/authentication.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'jwt'
+require 'openssl'
+
+module Tenkit
+  class Authentication
+    class << self
+      def new_token(expires_in: nil)
+        JWT.encode(payload(expires_in), key, 'ES256', header)
+      end
+
+      private
+
+      def header
+        {
+          alg: 'ES256',
+          kid: Tenkit.config.key_id,
+          id: "#{Tenkit.config.team_id}.#{Tenkit.config.service_id}"
+        }
+      end
+
+      def payload(expires_in)
+        issued_at = Time.new.to_i
+        expires_in ||= 600
+
+        {
+          iss: Tenkit.config.team_id,
+          iat: issued_at,
+          exp: issued_at + expires_in,
+          sub: Tenkit.config.service_id
+        }
+      end
+
+      def key
+        OpenSSL::PKey.read Tenkit.config.key
+      end
+    end
+  end
+end

--- a/lib/tenkit/client.rb
+++ b/lib/tenkit/client.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'jwt'
-require 'openssl'
 require 'httparty'
 require_relative './weather_response'
 
@@ -9,6 +7,8 @@ module Tenkit
   class Client
     include HTTParty
     base_uri 'https://weatherkit.apple.com/api/v1'
+
+    attr_reader :user_token
 
     DATA_SETS = {
       current_weather: 'currentWeather',
@@ -19,8 +19,10 @@ module Tenkit
       weather_alerts: 'weatherAlerts'
     }.freeze
 
-    def initialize
+    def initialize(user_token: nil)
       Tenkit.config.validate!
+
+      @user_token = user_token
     end
 
     def availability(lat, lon, country: 'US')
@@ -47,29 +49,8 @@ module Tenkit
       self.class.get(url, { headers: headers })
     end
 
-    def header
-      {
-        alg: 'ES256',
-        kid: Tenkit.config.key_id,
-        id: "#{Tenkit.config.team_id}.#{Tenkit.config.service_id}"
-      }
-    end
-
-    def payload
-      {
-        iss: Tenkit.config.team_id,
-        iat: Time.new.to_i,
-        exp: Time.new.to_i + 600,
-        sub: Tenkit.config.service_id
-      }
-    end
-
-    def key
-      OpenSSL::PKey.read Tenkit.config.key
-    end
-
     def token
-      JWT.encode payload, key, 'ES256', header
+      user_token || Authentication.new_token
     end
   end
 end


### PR DESCRIPTION
Library users could want to generate their own token externally.
Or using the `Authentication` module as a helper.

`user_token` could be named better.

Note: I've had this change in a fork for a while.
The use case is to allow caching tokens.

Might need adjustments to tests.