### PR TITLE
Add standardrb linter.

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,0 +1,13 @@
+name: Standard Ruby
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: write
+    steps:
+    - name: Standard Ruby
+      uses: standardrb/standard-ruby-action@v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/lib/tenkit.rb
+++ b/lib/tenkit.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative 'tenkit/container'
-require_relative 'tenkit/client'
-require_relative 'tenkit/config'
-require_relative 'tenkit/version'
-require_relative 'tenkit/weather'
-require_relative 'tenkit/weather_alert'
-require_relative 'tenkit/tenkit_error'
+require_relative "tenkit/container"
+require_relative "tenkit/client"
+require_relative "tenkit/config"
+require_relative "tenkit/version"
+require_relative "tenkit/weather"
+require_relative "tenkit/weather_alert"
+require_relative "tenkit/tenkit_error"
 
 module Tenkit
   class << self

--- a/lib/tenkit/client.rb
+++ b/lib/tenkit/client.rb
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
-require 'jwt'
-require 'openssl'
-require 'httparty'
-require_relative './weather_response'
-require_relative './weather_alert_response'
+require "jwt"
+require "openssl"
+require "httparty"
+require_relative "weather_response"
+require_relative "weather_alert_response"
 
 module Tenkit
   class Client
     include HTTParty
-    base_uri 'https://weatherkit.apple.com/api/v1'
+    base_uri "https://weatherkit.apple.com/api/v1"
 
     DATA_SETS = {
-      current_weather: 'currentWeather',
-      forecast_daily: 'forecastDaily',
-      forecast_hourly: 'forecastHourly',
-      forecast_next_hour: 'forecastNextHour',
-      trend_comparison: 'trendComparison',
-      weather_alerts: 'weatherAlerts'
+      current_weather: "currentWeather",
+      forecast_daily: "forecastDaily",
+      forecast_hourly: "forecastHourly",
+      forecast_next_hour: "forecastNextHour",
+      trend_comparison: "trendComparison",
+      weather_alerts: "weatherAlerts"
     }.freeze
 
     def initialize
       Tenkit.config.validate!
     end
 
-    def availability(lat, lon, country: 'US')
+    def availability(lat, lon, country: "US")
       get("/availability/#{lat}/#{lon}?country=#{country}")
     end
 
-    def weather(lat, lon, data_sets: [:current_weather], language: 'en')
+    def weather(lat, lon, data_sets: [:current_weather], language: "en")
       path_root = "/weather/#{language}/#{lat}/#{lon}?dataSets="
-      path = path_root + data_sets.map { |ds| DATA_SETS[ds] }.compact.join(',')
+      path = path_root + data_sets.map { |ds| DATA_SETS[ds] }.compact.join(",")
       response = get(path)
       WeatherResponse.new(response)
     end
 
-    def weather_alert(id, language: 'en')
+    def weather_alert(id, language: "en")
       path = "/weatherAlert/#{language}/#{id}"
       response = get(path)
       WeatherAlertResponse.new(response)
@@ -44,13 +44,13 @@ module Tenkit
     private
 
     def get(url)
-      headers = { Authorization: "Bearer #{token}" }
-      self.class.get(url, { headers: headers })
+      headers = {Authorization: "Bearer #{token}"}
+      self.class.get(url, {headers: headers})
     end
 
     def header
       {
-        alg: 'ES256',
+        alg: "ES256",
         kid: Tenkit.config.key_id,
         id: "#{Tenkit.config.team_id}.#{Tenkit.config.service_id}"
       }
@@ -70,7 +70,7 @@ module Tenkit
     end
 
     def token
-      JWT.encode payload, key, 'ES256', header
+      JWT.encode payload, key, "ES256", header
     end
   end
 end

--- a/lib/tenkit/config.rb
+++ b/lib/tenkit/config.rb
@@ -14,7 +14,7 @@ module Tenkit
     def validate!
       missing_required = REQUIRED_ATTRIBUTES.filter { |required| instance_variable_get(required).nil? }
       if missing_required.length > 0
-        raise TenkitError, "#{missing_required.join(', ')} cannot be blank. check that you have configured your credentials"
+        raise TenkitError, "#{missing_required.join(", ")} cannot be blank. check that you have configured your credentials"
       end
     end
   end

--- a/lib/tenkit/next_hour_forecast.rb
+++ b/lib/tenkit/next_hour_forecast.rb
@@ -1,7 +1,7 @@
 module Tenkit
   class NextHourForecast
     def initialize(forecast_next_hour)
-      return if forecast_next_hour.nil?
+      nil if forecast_next_hour.nil?
     end
   end
 end

--- a/lib/tenkit/version.rb
+++ b/lib/tenkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tenkit
-  VERSION = '0.0.7'
+  VERSION = "0.0.7"
 end

--- a/lib/tenkit/weather.rb
+++ b/lib/tenkit/weather.rb
@@ -1,25 +1,25 @@
-require_relative './next_hour_forecast'
-require_relative './trend_comparison'
-require_relative './weather_alert_collection'
+require_relative "next_hour_forecast"
+require_relative "trend_comparison"
+require_relative "weather_alert_collection"
 
 module Tenkit
   class Weather
     attr_reader :current_weather,
-                :forecast_daily,
-                :forecast_hourly,
-                :forecast_next_hour,
-                :trend_comparison,
-                :weather_alerts
+      :forecast_daily,
+      :forecast_hourly,
+      :forecast_next_hour,
+      :trend_comparison,
+      :weather_alerts
 
     def initialize(response)
       parsed_response = JSON.parse(response.body)
 
-      current_weather = parsed_response['currentWeather']
-      forecast_daily = parsed_response['forecastDaily']
-      forecast_hourly = parsed_response['forecastHourly']
-      forecast_next_hour = parsed_response['forecastNextHour']
-      trend_comparison = parsed_response['trendComparison']
-      weather_alerts = parsed_response['weatherAlerts']
+      current_weather = parsed_response["currentWeather"]
+      forecast_daily = parsed_response["forecastDaily"]
+      forecast_hourly = parsed_response["forecastHourly"]
+      forecast_next_hour = parsed_response["forecastNextHour"]
+      trend_comparison = parsed_response["trendComparison"]
+      weather_alerts = parsed_response["weatherAlerts"]
 
       @current_weather = CurrentWeather.new(current_weather)
       @forecast_daily = DailyForecast.new(forecast_daily)

--- a/lib/tenkit/weather_alert_collection.rb
+++ b/lib/tenkit/weather_alert_collection.rb
@@ -5,8 +5,8 @@ module Tenkit
     def initialize(weather_alerts)
       return if weather_alerts.nil?
 
-      @alerts = weather_alerts['alerts'].map { |alert| WeatherAlertSummary.new(alert) }
-      @details_url = weather_alerts['detailsUrl']
+      @alerts = weather_alerts["alerts"].map { |alert| WeatherAlertSummary.new(alert) }
+      @details_url = weather_alerts["detailsUrl"]
     end
   end
 end

--- a/lib/tenkit/weather_response.rb
+++ b/lib/tenkit/weather_response.rb
@@ -1,4 +1,4 @@
-require_relative './response'
+require_relative "response"
 
 module Tenkit
   class WeatherResponse < Response

--- a/spec/tenkit/spec_helper.rb
+++ b/spec/tenkit/spec_helper.rb
@@ -1,12 +1,12 @@
-require_relative '../../lib/tenkit'
+require_relative "../../lib/tenkit"
 
-require 'webmock/rspec'
-require 'dotenv'
+require "webmock/rspec"
+require "dotenv"
 Dotenv.load
 
 Tenkit.configure do |c|
-  c.team_id = ENV.fetch('TID', 'A1A1A1A1A1')
-  c.service_id = ENV.fetch('SID', 'com.mydomain.myapp')
-  c.key_id = ENV.fetch('KID', 'B2B2B2B2B2')
-  c.key = ENV.fetch('AUTH_KEY', '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----')
+  c.team_id = ENV.fetch("TID", "A1A1A1A1A1")
+  c.service_id = ENV.fetch("SID", "com.mydomain.myapp")
+  c.key_id = ENV.fetch("KID", "B2B2B2B2B2")
+  c.key = ENV.fetch("AUTH_KEY", '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----')
 end

--- a/spec/tenkit/tenkit/config_spec.rb
+++ b/spec/tenkit/tenkit/config_spec.rb
@@ -1,17 +1,17 @@
-require_relative '../../../lib/tenkit'
+require_relative "../../../lib/tenkit"
 
 RSpec.describe Tenkit::Config do
-  describe '#validate!' do
-    it 'raises a Tenkit::TenkitError exception if missing required config vals' do
+  describe "#validate!" do
+    it "raises a Tenkit::TenkitError exception if missing required config vals" do
       config = Tenkit::Config.new
       expect { config.validate! }.to raise_error Tenkit::TenkitError
-      config.team_id = '123'
+      config.team_id = "123"
       expect { config.validate! }.to raise_error Tenkit::TenkitError
-      config.service_id = 'abc'
+      config.service_id = "abc"
       expect { config.validate! }.to raise_error Tenkit::TenkitError
-      config.key_id = 'hij'
+      config.key_id = "hij"
       expect { config.validate! }.to raise_error Tenkit::TenkitError
-      config.key = '====PRIVATE KEY===='
+      config.key = "====PRIVATE KEY===="
       expect { config.validate! }.not_to raise_error
     end
   end

--- a/spec/tenkit/tenkit/weather_spec.rb
+++ b/spec/tenkit/tenkit/weather_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Tenkit::Weather do
 
     it "includes expected metadata" do
       expect(subject.name).to eq "CurrentWeather"
-      expect(subject.metadata.attribution_url).to start_with 'https://'
+      expect(subject.metadata.attribution_url).to start_with "https://"
       expect(subject.metadata.latitude).to be 37.32
       expect(subject.metadata.longitude).to be 122.03
     end
@@ -51,12 +51,12 @@ RSpec.describe Tenkit::Weather do
     end
 
     it "excludes learn_more_url node" do
-      expect(subject.respond_to? :learn_more_url).to be false
+      expect(subject.respond_to?(:learn_more_url)).to be false
     end
 
     it "includes expected metadata" do
       expect(subject.name).to eq "DailyForecast"
-      expect(subject.metadata.attribution_url).to start_with 'https://'
+      expect(subject.metadata.attribution_url).to start_with "https://"
       expect(subject.metadata.latitude).to be 37.32
       expect(subject.metadata.longitude).to be 122.03
     end
@@ -88,7 +88,7 @@ RSpec.describe Tenkit::Weather do
 
     it "includes expected metadata" do
       expect(subject.name).to eq "HourlyForecast"
-      expect(subject.metadata.attribution_url).to start_with 'https://'
+      expect(subject.metadata.attribution_url).to start_with "https://"
       expect(subject.metadata.latitude).to be 37.32
       expect(subject.metadata.longitude).to be 122.03
     end

--- a/tenkit.gemspec
+++ b/tenkit.gemspec
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
-require 'tenkit/version'
+$LOAD_PATH.push File.expand_path("lib", __dir__)
+require "tenkit/version"
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
-  s.name = 'tenkit'
+  s.name = "tenkit"
   s.version = Tenkit::VERSION
-  s.required_ruby_version = '>= 2.6.7'
-  s.summary = 'Wrapper for WeatherKit API'
-  s.description = 'Wrapper for Weatherkit API'
-  s.author = 'James Pierce'
-  s.email = 'james@superbasic.xyz'
-  s.homepage = 'https://github.com/superbasicxyz/tenkit'
-  s.license = 'MIT'
-  s.files = Dir['lib/tenkit.rb', 'lib/**/*.rb']
+  s.required_ruby_version = ">= 2.6.7"
+  s.summary = "Wrapper for WeatherKit API"
+  s.description = "Wrapper for Weatherkit API"
+  s.author = "James Pierce"
+  s.email = "james@superbasic.xyz"
+  s.homepage = "https://github.com/superbasicxyz/tenkit"
+  s.license = "MIT"
+  s.files = Dir["lib/tenkit.rb", "lib/**/*.rb"]
 
-  s.add_dependency 'httparty', '~> 0.21.0'
-  s.add_dependency 'jwt', '~> 2.7.0'
+  s.add_dependency "httparty", "~> 0.21.0"
+  s.add_dependency "jwt", "~> 2.7.0"
 
-  s.add_development_dependency 'bundler', '~> 2.4.22'
-  s.add_development_dependency 'dotenv', '~> 2.8'
-  s.add_development_dependency 'rake', '~> 12.3'
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'webmock', '~> 3.8'
+  s.add_development_dependency "bundler", "~> 2.4.22"
+  s.add_development_dependency "dotenv", "~> 2.8"
+  s.add_development_dependency "rake", "~> 12.3"
+  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "webmock", "~> 3.8"
 end


### PR DESCRIPTION
I've been using `standardrb --fix` to lint new files. If this linter is acceptable, this PR will enforce the linter with Github actions and bring everything up-to-date without changing the implementation. 

Note: I do like using single quotes when appropriate, but not having to mess with Rubocop configs seems worth it.