### PR TITLE
Client: Improve query params with specs

### DIFF
--- a/lib/tenkit/client.rb
+++ b/lib/tenkit/client.rb
@@ -53,11 +53,7 @@ module Tenkit
     def get(url, query: nil)
       headers = { Authorization: "Bearer #{token}" }
       params = { headers: headers }
-
-      if !query.nil?
-        params[:query] = query
-      end
-
+      params[:query] = query unless query.nil?
       self.class.get(url, params)
     end
 

--- a/lib/tenkit/client.rb
+++ b/lib/tenkit/client.rb
@@ -24,14 +24,21 @@ module Tenkit
       Tenkit.config.validate!
     end
 
-    def availability(lat, lon, country: 'US')
-      get("/availability/#{lat}/#{lon}?country=#{country}")
+    def availability(lat, lon, **options)
+      options[:country] ||= 'US'
+
+      query = { country: options[:country] }
+      get("/availability/#{lat}/#{lon}", query: query)
     end
 
-    def weather(lat, lon, data_sets: [:current_weather], language: 'en')
-      path_root = "/weather/#{language}/#{lat}/#{lon}?dataSets="
-      path = path_root + data_sets.map { |ds| DATA_SETS[ds] }.compact.join(',')
-      response = get(path)
+    def weather(lat, lon, **options)
+      options[:data_sets] ||= [:current_weather]
+      options[:language] ||= 'en'
+
+      query = weather_query_for_options(options)
+      path = "/weather/#{options[:language]}/#{lat}/#{lon}"
+
+      response = get(path, query: query)
       WeatherResponse.new(response)
     end
 
@@ -43,9 +50,15 @@ module Tenkit
 
     private
 
-    def get(url)
+    def get(url, query: nil)
       headers = { Authorization: "Bearer #{token}" }
-      self.class.get(url, { headers: headers })
+      params = { headers: headers }
+
+      if !query.nil?
+        params[:query] = query
+      end
+
+      self.class.get(url, params)
     end
 
     def header
@@ -71,6 +84,23 @@ module Tenkit
 
     def token
       JWT.encode payload, key, 'ES256', header
+    end
+
+    # Snake case options to expected query parameters
+    # https://developer.apple.com/documentation/weatherkitrestapi/get-api-v1-weather-_language_-_latitude_-_longitude_#query-parameters
+    def weather_query_for_options(options)
+      data_sets_param = options[:data_sets].map { |ds| DATA_SETS[ds] }.compact.join(',')
+
+      {
+        countryCode: options[:country_code],
+        currentAsOf: options[:current_as_of],
+        dailyEnd: options[:daily_end],
+        dailyStart: options[:daily_start],
+        dataSets: data_sets_param,
+        hourlyEnd: options[:hourly_end],
+        hourlyStart: options[:hourly_start],
+        timezone: options[:timezone]
+      }.compact
     end
   end
 end

--- a/lib/tenkit/utils.rb
+++ b/lib/tenkit/utils.rb
@@ -5,5 +5,11 @@ module Tenkit
 
       str.gsub(/(.)([A-Z])/, '\1_\2').sub(/_UR_L$/, "_URL").downcase
     end
+
+    def self.camel(str)
+      return str.camelize(:lower) if str.respond_to? :camelize
+
+      str.gsub(/_(.)/) {|e| $1.upcase}
+    end
   end
 end

--- a/spec/tenkit/tenkit/utils_spec.rb
+++ b/spec/tenkit/tenkit/utils_spec.rb
@@ -1,15 +1,16 @@
 require_relative "../spec_helper"
 RSpec.describe Tenkit::Utils do
+  let(:camel) { "someSpecialCaseString" }
+  let(:snake) { "some_special_case_string" }
+
   subject { Tenkit::Utils }
 
   describe ".snake" do
-    let(:simple) { "someCamelCaseString" }
-    let(:correct) { "some_camel_case_string" }
     let(:complex) { "someAWSCredentials" }
     let(:mangled) { "some_aw_scredentials" }
 
     it "converts to snake case" do
-      expect(subject.snake(simple)).to eq correct
+      expect(subject.snake(camel)).to eq snake
     end
 
     context "when passed an acronym" do
@@ -26,10 +27,28 @@ RSpec.describe Tenkit::Utils do
       end
     end
   end
+
+  describe ".camel" do
+    it "converts to camel case" do
+      expect(subject.camel(snake)).to eq camel
+    end
+
+    context "when a proper camelize package is available" do
+      let(:patched_string) { PatchedString.new snake }
+
+      it "uses string camelize method" do
+        expect(subject.camel(patched_string)).to eq :correct
+      end
+    end
+  end
 end
 
 class PatchedString < String
   def underscore
+    :correct
+  end
+
+  def camelize(sym)
     :correct
   end
 end


### PR DESCRIPTION
We could use more specs on options.params. This PR as a place for the other PR to swipe from. 